### PR TITLE
nuxt generate error fix.

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -49,7 +49,8 @@ module.exports = function cacheRenderer(nuxt, config) {
     }
 
     function defaultCacheKeyBuilder(route, context) {
-      const hostname = context.req.hostname || context.req.host;
+      var hostname = context.req && context.req.hostname || context.req && context.req.host;
+      if(!hostname) return;
       const cacheKey = config.cache.useHostPrefix === true && hostname
         ? path.join(hostname, route)
         : route;


### PR DESCRIPTION
if context.req.host and hostname does not exist, can not build.