### PR TITLE
useHostPrefix option was not working

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -49,7 +49,7 @@ module.exports = function cacheRenderer(nuxt, config) {
     }
 
     function defaultCacheKeyBuilder(route, context) {
-      var hostname = context.req && context.req.hostname || context.req && context.req.host;
+      var hostname = context.req && context.req.hostname || context.req && context.req.host || context.req && context.req.headers && context.req.headers.host;
       if(!hostname) return;
       const cacheKey = config.cache.useHostPrefix === true && hostname
         ? path.join(hostname, route)


### PR DESCRIPTION
I 've set my useHostPrefix option to true, but it does not work. I found out that hostname variable was always `undefined`, so I 've added `context.req.headers.host` and it does work for me.