### PR TITLE
fix(middleware): cache doesn't work if pages is empty when used metho…

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -35,7 +35,7 @@ module.exports = function cacheRenderer(nuxt, config) {
         return;
     }
 
-    const methodKeyDoesNotExist = Boolean(config.cache.key);
+    const methodKeyDoesNotExist = !Boolean(config.cache.key);
     if (methodKeyDoesNotExist && (!Array.isArray(config.cache.pages) || !config.cache.pages.length)) {
       return;
     }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -31,8 +31,13 @@ module.exports = function cacheRenderer(nuxt, config) {
       config = this.options;
     }
 
-    if (!config.cache || !Array.isArray(config.cache.pages) || !config.cache.pages.length || !nuxt.renderer) {
+    if (!config.cache || !nuxt.renderer) {
         return;
+    }
+
+    const methodKeyDoesNotExist = Boolean(config.cache.key);
+    if (methodKeyDoesNotExist && (!Array.isArray(config.cache.pages) || !config.cache.pages.length)) {
+      return;
     }
 
     function isCacheFriendly(path, context) {


### PR DESCRIPTION
cache doesn't work if pages is empty when used method 'key'