### PR TITLE
Make Redis package optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   "homepage": "https://github.com/arash16/nuxt-ssr-cache#readme",
   "dependencies": {
     "bluebird": "^3.5.5",
-    "cache-manager": "^2.9.1",
-    "redis": "^2.8.0"
+    "cache-manager": "^2.9.1"   
   },
   "optionalDependencies": {
     "cache-manager-memcached-store": "^2.1.0",
-    "cache-manager-redis": "^0.6.0"
+    "cache-manager-redis": "^0.6.0",
+    "redis": "^2.8.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",


### PR DESCRIPTION
If we are going to use memory cache, redis can be omitted.