### PR TITLE
feat: set TTL values for pages individually

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -68,14 +68,17 @@ module.exports = function cacheRenderer(nuxt, config) {
         // hopefully cache reset is finished up to this point.
         tryStoreVersion(cache, currentVersion);
 
-        const cacheKey = (config.cache.key || defaultCacheKeyBuilder)(route, context);
+        const keyConfig = (config.cache.key || defaultCacheKeyBuilder)(route, context);
+        const cacheKey = typeof keyConfig === 'object' ? keyConfig.key : keyConfig
+        const ttl = typeof keyConfig === 'object' ? keyConfig.ttl : config.cache.store.ttl
+
         if (!cacheKey) return renderRoute(route, context);
 
         function renderSetCache(){
             return renderRoute(route, context)
                 .then(function(result) {
                     if (!result.error && !result.redirected) {
-                        cache.setAsync(cacheKey, serialize(result));
+                        cache.setAsync(cacheKey, serialize(result), { ttl });
                     }
                     return result;
                 });


### PR DESCRIPTION
Currently, the same value of TTL will be applied for all cache keys. That is a great idea!

But... sometimes, high incoming traffic to some pages which is low update frequency (ex: single article,...). These pages should be cached longer than the other pages.

This PR will allow us to set TTL for a specific cache key by returning the object in `key(route, context)`. EX:

```javascript
pages: [
  '/',
],

store: {
  type: 'redis',
  max: 100,
  ttl: 600, // 10 minutes - default
},

key: (route, context) => {
  if (/\/p\/.+/.test(context.req.url)) {
    // cache will available in 24 hours for pages: /p/*
    return { key: context.req.url, ttl: 86400 }
  }

  return context.req.url // use default TTL
},
```

I think this is a helpful feature. Could you please check it?